### PR TITLE
Enhance activities API with signup validation and unregistration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for intramural and regional tournaments",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Tennis training and friendly matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 10,
+        "participants": ["alex@mergington.edu", "jordan@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Painting, drawing, and sculpture techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["isabella@mergington.edu"]
+    },
+    "Music Ensemble": {
+        "description": "Join the school orchestra and perform in concerts",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["noah@mergington.edu", "ava@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Explore STEM topics through hands-on experiments and projects",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["liam@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["mia@mergington.edu", "ethan@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsHtml = details.participants.length > 0 
+          ? `<ul class="participants-list">${details.participants.map(p => `<li><span class="participant-email">${p}</span><button class="remove-btn" data-activity="${name}" data-email="${p}" title="Remove participant">&#x2715;</button></li>`).join('')}</ul>`
+          : '<p class="no-participants">No participants yet</p>';
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <strong>Participants:</strong>
+            ${participantsHtml}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +70,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +87,41 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle unregister clicks
+  activitiesList.addEventListener("click", async (event) => {
+    const btn = event.target.closest(".remove-btn");
+    if (!btn) return;
+
+    const activity = btn.dataset.activity;
+    const email = btn.dataset.email;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,68 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #ddd;
+  background-color: #f0f7ff;
+  padding: 12px;
+  border-radius: 4px;
+}
+
+.participants-section strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #0066cc;
+}
+
+.participants-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: 4px;
+  transition: background-color 0.15s;
+}
+
+.participants-list li:hover {
+  background-color: #e3f2fd;
+}
+
+.participant-email {
+  flex: 1;
+  color: #333;
+}
+
+.remove-btn {
+  background: none;
+  border: none;
+  color: #c62828;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 6px;
+  border-radius: 50%;
+  line-height: 1;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.remove-btn:hover {
+  background-color: #ffcdd2;
+  color: #b71c1c;
+}
+
+.no-participants {
+  font-style: italic;
+  color: #999;
+  margin: 0;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,120 @@
+import copy
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+# Store a deep copy of the original activities to reset state between tests
+_original_activities = copy.deepcopy(activities)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset the in-memory activities dict before each test."""
+    activities.clear()
+    activities.update(copy.deepcopy(_original_activities))
+
+
+client = TestClient(app)
+
+
+# --- GET / ---
+
+def test_root_redirects_to_index():
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+# --- GET /activities ---
+
+def test_get_activities_returns_all():
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 9
+
+
+def test_get_activities_contain_expected_fields():
+    response = client.get("/activities")
+    data = response.json()
+    for name, details in data.items():
+        assert "description" in details
+        assert "schedule" in details
+        assert "max_participants" in details
+        assert "participants" in details
+        assert isinstance(details["participants"], list)
+
+
+def test_get_activities_includes_known_activity():
+    response = client.get("/activities")
+    data = response.json()
+    assert "Chess Club" in data
+    assert data["Chess Club"]["schedule"] == "Fridays, 3:30 PM - 5:00 PM"
+
+
+# --- POST /activities/{name}/signup ---
+
+def test_signup_success():
+    response = client.post("/activities/Chess Club/signup?email=newstudent@mergington.edu")
+    assert response.status_code == 200
+    assert "newstudent@mergington.edu" in response.json()["message"]
+
+    # Verify participant was added
+    activities_resp = client.get("/activities")
+    assert "newstudent@mergington.edu" in activities_resp.json()["Chess Club"]["participants"]
+
+
+def test_signup_activity_not_found():
+    response = client.post("/activities/Nonexistent Club/signup?email=test@mergington.edu")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_duplicate_email():
+    response = client.post("/activities/Chess Club/signup?email=michael@mergington.edu")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+# --- DELETE /activities/{name}/signup ---
+
+def test_unregister_success():
+    response = client.delete("/activities/Chess Club/signup?email=michael@mergington.edu")
+    assert response.status_code == 200
+    assert "michael@mergington.edu" in response.json()["message"]
+
+    # Verify participant was removed
+    activities_resp = client.get("/activities")
+    assert "michael@mergington.edu" not in activities_resp.json()["Chess Club"]["participants"]
+
+
+def test_unregister_activity_not_found():
+    response = client.delete("/activities/Nonexistent Club/signup?email=test@mergington.edu")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_email_not_found():
+    response = client.delete("/activities/Chess Club/signup?email=nobody@mergington.edu")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student is not signed up for this activity"
+
+
+# --- Cross-endpoint integration ---
+
+def test_signup_then_unregister():
+    # Sign up
+    signup_resp = client.post("/activities/Art Studio/signup?email=newartist@mergington.edu")
+    assert signup_resp.status_code == 200
+
+    # Verify added
+    data = client.get("/activities").json()
+    assert "newartist@mergington.edu" in data["Art Studio"]["participants"]
+
+    # Unregister
+    unreg_resp = client.delete("/activities/Art Studio/signup?email=newartist@mergington.edu")
+    assert unreg_resp.status_code == 200
+
+    # Verify removed
+    data = client.get("/activities").json()
+    assert "newartist@mergington.edu" not in data["Art Studio"]["participants"]


### PR DESCRIPTION
This pull request introduces several new activities, adds the ability for users to unregister from activities, improves the frontend to display and manage participants, and significantly expands automated test coverage for activity signups and removals. These changes enhance both the user experience and the reliability of the application.

**Backend enhancements:**

* Added new activities to the `activities` dictionary in `src/app.py`, including Basketball Team, Tennis Club, Art Studio, Music Ensemble, Science Club, and Debate Team.
* Implemented an endpoint to allow users to unregister from activities (`/activities/{activity_name}/signup` with DELETE), including error handling for non-existent activities and participants not signed up.

**Frontend improvements:**

* Updated the UI to display a styled participant list for each activity, with remove buttons next to each participant. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R23-R35) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R138)
* Added client-side logic to handle participant removal via the new unregister API, updating the UI accordingly.
* Ensured the activity list refreshes after signup or removal to reflect the latest state.

**Testing:**

* Added comprehensive tests in `tests/test_app.py` to cover activity retrieval, signup, duplicate prevention, unregistration, error cases, and integration flows. Tests reset the in-memory activity data between runs for isolation.